### PR TITLE
bump version to v0.4.1

### DIFF
--- a/pgr-bin/Cargo.toml
+++ b/pgr-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgr-bin"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Jason Chin <cschin@infoecho.net>"]
 

--- a/pgr-bin/src/bin/pgr-pbundle-bed2svg.rs
+++ b/pgr-bin/src/bin/pgr-pbundle-bed2svg.rs
@@ -40,6 +40,9 @@ struct CmdOptions {
     /// the track panel size in pixel
     #[clap(long, default_value_t = 1600)]
     track_panel_width: usize,
+    /// the factor to increase height of each track
+    #[clap(long, default_value_t = 1.0)]
+    track_scaling: f32,
     /// the left padding in pixel
     #[clap(long)]
     left_padding: Option<usize>,
@@ -310,9 +313,9 @@ fn main() -> Result<(), std::io::Error> {
 
     let mut y_offset = 0.0_f32;
     let delta_y = if !annotation_region_record.is_empty() {
-        22.0_f32 + args.annotation_region_stroke_width * 0.5
+        22.0_f32 * args.track_scaling + args.annotation_region_stroke_width * 0.5
     } else {
-        16.0_f32
+        16.0_f32 * args.track_scaling
     };
 
     // generate the bundle path elements
@@ -338,7 +341,7 @@ fn main() -> Result<(), std::io::Error> {
                     }
 
                     let arror_end = end as f32;
-                    let halfwidth = 5.0;
+                    let halfwidth = 5.0 * args.track_scaling;
                     let end =
                         if direction == 0 {
                             if end as f32 - halfwidth < bgn {

--- a/pgr-db/Cargo.toml
+++ b/pgr-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgr-db"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Jason Chin <cschin@infoecho.net>"]
 build = "build.rs"

--- a/pgr-db/src/seq_db.rs
+++ b/pgr-db/src/seq_db.rs
@@ -808,9 +808,9 @@ impl CompactSeqDB {
 impl CompactSeqDB {
     pub fn write_to_frag_files(&self, file_prefix: String) {
         let mut sdx_file =
-            BufWriter::new(File::create(file_prefix.clone() + ".sdx").expect("csq file open fail"));
+            BufWriter::new(File::create(file_prefix.clone() + ".sdx").expect("sdx file creating fail\n"));
         let mut frg_file =
-            BufWriter::new(File::create(file_prefix + ".frg").expect("frg file open fail"));
+            BufWriter::new(File::create(file_prefix + ".frg").expect("frg file creating fail\n"));
 
         let config = config::standard();
 
@@ -844,11 +844,11 @@ impl CompactSeqDB {
             let l = v.len();
             frag_addr_offeset.push((offset, v.len(), *frag_len));
             offset += l;
-            frg_file.write_all(v).expect("frag file writing error");
+            frg_file.write_all(v).expect("frag file writing error\n");
         });
 
         bincode::encode_into_std_write((frag_addr_offeset, &self.seqs), &mut sdx_file, config)
-            .expect("csq file writing error");
+            .expect("sdx file writing error\n");
         //bincode::encode_into_std_write(compressed_frags, &mut frg_file, config)
         //    .expect(" frag file writing error");
     }
@@ -1233,7 +1233,7 @@ pub fn write_shmr_map_file(
     shmmr_map: &ShmmrToFrags,
     filepath: String,
 ) -> Result<(), std::io::Error> {
-    let mut out_file = File::create(filepath).expect("open fail");
+    let mut out_file = File::create(filepath).expect("open fail while writing the SHIMMER map (.mdb) file\n");
     let mut buf = Vec::<u8>::new();
 
     buf.extend("mdb".to_string().into_bytes());
@@ -1265,7 +1265,7 @@ pub fn write_shmr_map_file(
 }
 
 pub fn read_mdb_file(filepath: String) -> Result<(ShmmrSpec, ShmmrToFrags), io::Error> {
-    let mut in_file = File::open(filepath).expect("open fail");
+    let mut in_file = File::open(filepath).expect("Error while opening the SHIMMER map file (.mdb) file");
     let mut buf = Vec::<u8>::new();
 
     let mut u64bytes = [0_u8; 8];
@@ -1346,7 +1346,7 @@ pub fn read_mdb_file(filepath: String) -> Result<(ShmmrSpec, ShmmrToFrags), io::
 }
 
 pub fn read_mdb_file_parallel(filepath: String) -> Result<(ShmmrSpec, ShmmrToFrags), io::Error> {
-    let mut in_file = File::open(filepath).expect("open fail");
+    let mut in_file = File::open(filepath).expect("open fail while reading the SHIMMER map (.mdb) file");
     let mut buf = Vec::<u8>::new();
 
     let mut u64bytes = [0_u8; 8];

--- a/pgr-tk-workstation/Dockerfile
+++ b/pgr-tk-workstation/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
 
 
 RUN . /opt/conda/bin/activate && \
-conda install -y python=3.8.10 jupyterlab numpy networkx==2.4 matplotlib bokeh && conda clean -ya
+conda install -y python=3.10 jupyterlab numpy networkx==2.4 matplotlib bokeh && conda clean -ya
 
 #RUN conda install -y  --channel=conda-forge \
 #        matplotlib \
@@ -35,11 +35,16 @@ RUN pip3 install -U --no-cache-dir \
     networkx==2.8.2 \
     papermill==2.3.4 \
     pydot==1.4.2 \
-    sklearn
+    scikit-learn
 
-COPY pgrtk-0.4.0_dev-cp38-cp38-linux_x86_64.whl /tmp
-RUN pip install /tmp/pgrtk-0.4.0_dev-cp38-cp38-linux_x86_64.whl
-RUN rm /tmp/pgrtk-0.4.0_dev-cp38-cp38-linux_x86_64.whl
+RUN echo deb http://http.us.debian.org/debian/ testing non-free contrib main > /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y libc6 libstdc++6
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /opt/conda/bin/../lib/libstdc++.so.6
+
+COPY pgrtk-0.4.0-cp310-cp310-linux_x86_64.whl /tmp
+RUN pip install /tmp/pgrtk-0.4.0-cp310-cp310-linux_x86_64.whl
+RUN rm /tmp/pgrtk-0.4.0-cp310-cp310-linux_x86_64.whl
 RUN mkdir -p /opt/bin/ /wd/
 COPY jupyterlab.sh /opt/bin/
 CMD /bin/bash /opt/bin/jupyterlab.sh

--- a/pgr-tk-workstation/build.sh
+++ b/pgr-tk-workstation/build.sh
@@ -1,2 +1,2 @@
-cp ../target/wheels/pgrtk-0.4.0_dev-cp38-cp38-linux_x86_64.whl .
-docker build -t cschin/pgr-tk-ws:v0.4.0_dev .
+cp ../target/wheels/pgrtk-0.4.0-cp310-cp310-linux_x86_64.whl .
+docker build -t cschin/pgr-tk-ws:v0.4.0 .

--- a/pgr-tk/Cargo.toml
+++ b/pgr-tk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrtk"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jason Chin <cschin@infoecho.net>"]
 edition = "2018"
 


### PR DESCRIPTION
Most minor tweaks, 
1. addition functionality on `pgr-pbundle-bed2svg`
2. add `pgr-compare-cov`, `pgr-compare-cov2`
3. add ` pgr-pbundle-bed2offset.rs`
4. pgr-pbundle-decomp now support projecting new sequence onto a MAP-Graph built from different set of sequences
5. support query fasta files in `pgr-query`
6. fix a graph traversal bug in `pgr-db/src/graph_utils.rs`  
7. fix a bug in the sequence reconstruction
8. bump the Docker for workstation to new version of python
9. 